### PR TITLE
moving to use low level storage API client lib

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -4,9 +4,9 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	storage "code.google.com/p/google-api-go-client/storage/v1"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
+	storage "google.golang.org/api/storage/v1"
 )
 
 func getAuthenticatedClient(ctx context.Context, jwtFileLocation string) (*http.Client, error) {
@@ -15,7 +15,7 @@ func getAuthenticatedClient(ctx context.Context, jwtFileLocation string) (*http.
 		return nil, err
 	}
 
-	jwtConf, err := google.JWTConfigFromJSON(data, storage.DevstorageFull_controlScope)
+	jwtConf, err := google.JWTConfigFromJSON(data, storage.DevstorageFullControlScope)
 	if err != nil {
 		return nil, err
 	}

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	storage "code.google.com/p/google-api-go-client/storage/v1"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+)
+
+func getAuthenticatedClient(ctx context.Context, jwtFileLocation string) (*http.Client, error) {
+	data, err := ioutil.ReadFile(jwtFileLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	jwtConf, err := google.JWTConfigFromJSON(data, storage.DevstorageFull_controlScope)
+	if err != nil {
+		return nil, err
+	}
+	return jwtConf.Client(ctx), nil
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,10 @@
 hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-updated: 2016-01-17T17:55:01.291176332-08:00
+updated: 2016-01-17T18:04:18.967836377-08:00
 imports:
+- name: code.google.com/p/goauth2
+  version: 222e66a2882e
 - name: code.google.com/p/google-api-go-client
   version: 6ddfebb10ece
-  subpackages:
-  - /storage/v1
-- name: github.com/golang/glog
-  version: fca8c8854093a154ff1eb580aae10276ad6b1b5f
-- name: github.com/golang/protobuf
-  version: 2402d76f3d41f928c7902a765dfc872356dd3aad
 - name: github.com/kelseyhightower/envconfig
   version: 12c18e8343f6eb5fc3a9d5c8dc353e42e6bb40b9
 - name: golang.org/x/net
@@ -21,10 +17,6 @@ imports:
   - google
 - name: google.golang.org/api
   version: b2be3c69519a81292faa7016d3c87f8b68c6f0d9
-- name: google.golang.org/appengine
-  version: 54bf9150c922186bfc45a00bf9dfcb91a5063275
-- name: google.golang.org/cloud
-  version: 6f469c6f5e20fde4c2088ed8b80bfa7ae296e622
-- name: google.golang.org/grpc
-  version: 5da22b92e9485c15a6b284d52cc54d6580864c99
+  subpackages:
+  - /storage/v1
 devImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,32 +1,30 @@
 hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-updated: 2016-01-03T22:18:57.625545989Z
+updated: 2016-01-17T17:55:01.291176332-08:00
 imports:
+- name: code.google.com/p/google-api-go-client
+  version: 6ddfebb10ece
+  subpackages:
+  - /storage/v1
 - name: github.com/golang/glog
   version: fca8c8854093a154ff1eb580aae10276ad6b1b5f
 - name: github.com/golang/protobuf
-  version: 68415e7123da32b07eab49c96d2c4d6158360e9b
+  version: 2402d76f3d41f928c7902a765dfc872356dd3aad
 - name: github.com/kelseyhightower/envconfig
   version: 12c18e8343f6eb5fc3a9d5c8dc353e42e6bb40b9
-- name: golang.org/x/crypto
-  version: f18420efc3b4f8e9f3d51f6bd2476e92c46260e9
 - name: golang.org/x/net
-  version: 0cb26f788dd4625d1956c6fd97ffc4c90669d129
+  version: c92cdcb05f66ce5b61460e23498d2dc5fcf69aaf
   subpackages:
   - context
 - name: golang.org/x/oauth2
   version: 2baa8a1b9338cf13d9eeb27696d761155fa480be
   subpackages:
   - google
-- name: golang.org/x/text
-  version: cf4986612c83df6c55578ba198316d1684a9a287
 - name: google.golang.org/api
-  version: dc6d2353af16e2a2b0ff6986af051d473a4ed468
+  version: b2be3c69519a81292faa7016d3c87f8b68c6f0d9
 - name: google.golang.org/appengine
-  version: 58c0e2a2044a8d1abd8dd1d97939cd74497d0806
+  version: 54bf9150c922186bfc45a00bf9dfcb91a5063275
 - name: google.golang.org/cloud
-  version: 6fdcab499d2c45e2939521c4047855f12a745a1d
-  subpackages:
-  - storage
+  version: 6f469c6f5e20fde4c2088ed8b80bfa7ae296e622
 - name: google.golang.org/grpc
-  version: 78905999da08d7f87d5dd11608fa79ff8700daa8
+  version: 5da22b92e9485c15a6b284d52cc54d6580864c99
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,6 +7,6 @@ import:
 - package: golang.org/x/oauth2
   subpackages:
   - google
-- package: code.google.com/p/google-api-go-client
+- package: google.golang.org/api
   subpackages:
   - /storage/v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,8 +1,12 @@
 package: main
 import:
-  - package: github.com/kelseyhightower/envconfig
-  - package: golang.org/x/net/context
-  - package: golang.org/x/oauth2
-  - package: golang.org/x/oauth2/google
-  - package: google.golang.org/cloud
-  - package: google.golang.org/cloud/storage
+- package: github.com/kelseyhightower/envconfig
+- package: golang.org/x/net
+  subpackages:
+  - context
+- package: golang.org/x/oauth2
+  subpackages:
+  - google
+- package: code.google.com/p/google-api-go-client
+  subpackages:
+  - /storage/v1

--- a/main.go
+++ b/main.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"sync"
 
-	storage "code.google.com/p/google-api-go-client/storage/v1"
 	"github.com/kelseyhightower/envconfig"
 	"golang.org/x/net/context"
+	storage "google.golang.org/api/storage/v1"
 )
 
 // Config is the envconfig compatible struct to store config values that are input to gcsup

--- a/upload.go
+++ b/upload.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	storage "code.google.com/p/google-api-go-client/storage/v1"
+	storage "google.golang.org/api/storage/v1"
 )
 
 func upload(svc *storage.Service, conf Config, from, to string) error {
@@ -17,7 +17,7 @@ func upload(svc *storage.Service, conf Config, from, to string) error {
 		ContentLanguage: "en",
 		ContentType:     getMimeType(from),
 	}
-	call := svc.Objects.Insert(conf.BucketName, objMeta).Media(fd).PredefinedAcl("publicRead")
+	call := svc.Objects.Insert(conf.BucketName, objMeta).Name(to).Media(fd).PredefinedAcl("publicRead")
 	if _, err := call.Do(); err != nil {
 		return err
 	}

--- a/upload.go
+++ b/upload.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+
+	storage "code.google.com/p/google-api-go-client/storage/v1"
+)
+
+func upload(svc *storage.Service, conf Config, from, to string) error {
+	fd, err := os.Open(from)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+
+	objMeta := &storage.Object{
+		ContentLanguage: "en",
+		ContentType:     getMimeType(from),
+	}
+	call := svc.Objects.Insert(conf.BucketName, objMeta).Media(fd).PredefinedAcl("publicRead")
+	if _, err := call.Do(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/upload.go
+++ b/upload.go
@@ -14,10 +14,11 @@ func upload(svc *storage.Service, conf Config, from, to string) error {
 	defer fd.Close()
 
 	objMeta := &storage.Object{
+		Name:            to,
 		ContentLanguage: "en",
 		ContentType:     getMimeType(from),
 	}
-	call := svc.Objects.Insert(conf.BucketName, objMeta).Name(to).Media(fd).PredefinedAcl("publicRead")
+	call := svc.Objects.Insert(conf.BucketName, objMeta).PredefinedAcl("publicRead").Media(fd)
 	if _, err := call.Do(); err != nil {
 		return err
 	}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"mime"
+	"strings"
+)
+
+func getMimeType(filename string) string {
+	idx := strings.LastIndex(filename, ".")
+	if idx == -1 {
+		return ""
+	}
+	return mime.TypeByExtension(filename[idx:])
+}


### PR DESCRIPTION
this is a big change that works at a slightly lower level, but allows us to set the `publicRead` [predefined ACL](https://cloud.google.com/storage/docs/access-control?hl=en#predefined-acl)
